### PR TITLE
Feature/minor release compute resource updates

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -424,7 +424,7 @@
       "tasks": {
         "alignment": {
           "key": "alignment",
-          "digest": "flxykowhis4bbjax5vqgwpf6jo6alaj5",
+          "digest": "2iwirmth5ibujbqn77nk73zxxtet7det",
           "tests": [
             {
               "inputs": {

--- a/workflows/cohort_analysis/cohort_analysis.wdl
+++ b/workflows/cohort_analysis/cohort_analysis.wdl
@@ -32,7 +32,7 @@ workflow cohort_analysis {
 	}
 
 	String sub_workflow_name = "cohort_analysis"
-	String sub_workflow_version = "1.1.0"
+	String sub_workflow_version = "1.1.1"
 
 	Array[Array[String]] workflow_info = [[run_timestamp, workflow_name, workflow_version, workflow_release]]
 

--- a/workflows/downstream/downstream.wdl
+++ b/workflows/downstream/downstream.wdl
@@ -31,7 +31,7 @@ workflow downstream {
 	}
 
 	String sub_workflow_name = "downstream"
-	String sub_workflow_version = "1.1.0"
+	String sub_workflow_version = "1.1.1"
 
 	Array[Array[String]] workflow_info = [[run_timestamp, workflow_name, workflow_version, workflow_release]]
 

--- a/workflows/main.wdl
+++ b/workflows/main.wdl
@@ -40,7 +40,7 @@ workflow pmdbs_bulk_rnaseq_analysis {
 
 	String workflow_execution_path = "workflow_execution"
 	String workflow_name = "pmdbs_bulk_rnaseq"
-	String workflow_version = "v1.1.0"
+	String workflow_version = "v1.1.1"
 	String workflow_release = "https://github.com/ASAP-CRN/pmdbs-bulk-rnaseq-wf/releases/tag/pmdbs_bulk_rnaseq_analysis-~{workflow_version}"
 
 	call GetWorkflowMetadata.get_workflow_metadata {

--- a/workflows/upstream/alignment_quantification/alignment_quantification.wdl
+++ b/workflows/upstream/alignment_quantification/alignment_quantification.wdl
@@ -99,7 +99,7 @@ task alignment {
 
 		tar -xzvf ~{star_genome_dir_tar_gz}
 
-		/usr/bin/time -v STAR \
+		STAR \
 			--runThreadN ~{threads - 1} \
 			--genomeDir star_genome_dir \
 			--readFilesIn ~{sep=',' trimmed_fastq_R1s} ~{sep=',' trimmed_fastq_R2s} \
@@ -192,12 +192,6 @@ task index_aligned_bam {
 
 	command <<<
 		set -euo pipefail
-
-		# STAR can produce an empty Aligned.sortedByCoord.out.bam and not error out; check
-		if [ ! -s ~{aligned_bam} ]; then
-			echo "[ERROR] Aligned.sortedByCoord.out.bam is empty; exiting"
-			exit 1
-		fi
 
 		samtools index \
 			-@ ~{threads} \

--- a/workflows/upstream/alignment_quantification/alignment_quantification.wdl
+++ b/workflows/upstream/alignment_quantification/alignment_quantification.wdl
@@ -79,7 +79,8 @@ task alignment {
 
 	Int threads = 48
 	Int mem_gb = ceil(threads * 2)
-	Int disk_size = ceil((size(star_genome_dir_tar_gz, "GB") + size(flatten([trimmed_fastq_R1s, trimmed_fastq_R2s]), "GB")) * 5 + 300)
+	Int sort_bam_mem_bytes = (mem_gb - 20) * 1024 * 1024 * 1024
+	Int disk_size = ceil((size(star_genome_dir_tar_gz, "GB") + size(flatten([trimmed_fastq_R1s, trimmed_fastq_R2s]), "GB")) * 5 + 500)
 
 	command <<<
 		set -euo pipefail
@@ -100,7 +101,7 @@ task alignment {
 			--alignMatesGapMax 1000000 \
 			--twopassMode Basic \
 			--quantMode TranscriptomeSAM \
-			--limitBAMsortRAM 80000000000 # should not exceed ~{mem_gb}
+			--limitBAMsortRAM ~{sort_bam_mem_bytes}
 
 		echo "Validating aligned and sorted BAM"
 		samtools quickcheck "~{sample_id}.Aligned.sortedByCoord.out.bam"

--- a/workflows/upstream/alignment_quantification/alignment_quantification.wdl
+++ b/workflows/upstream/alignment_quantification/alignment_quantification.wdl
@@ -169,6 +169,12 @@ task index_aligned_bam {
 	command <<<
 		set -euo pipefail
 
+		# STAR can produce an empty Aligned.sortedByCoord.out.bam and not error out; check
+		if [ ! -s ~{aligned_bam} ]; then
+			echo "[ERROR] Aligned.sortedByCoord.out.bam is empty; exiting"
+			exit 1
+		fi
+
 		samtools index \
 			-@ ~{threads} \
 			~{aligned_bam}

--- a/workflows/upstream/alignment_quantification/alignment_quantification.wdl
+++ b/workflows/upstream/alignment_quantification/alignment_quantification.wdl
@@ -114,6 +114,12 @@ task alignment {
 			--quantMode TranscriptomeSAM \
 			--limitBAMsortRAM 35000000000
 
+		echo "Syncing filesystem..."
+		sync
+
+		echo "Verifying BAM file integrity..."
+		samtools quickcheck -v ~{sample_id}.Aligned.sortedByCoord.out.bam
+
 		upload_outputs \
 			-b ~{billing_project} \
 			-d ~{raw_data_path} \

--- a/workflows/upstream/alignment_quantification/alignment_quantification.wdl
+++ b/workflows/upstream/alignment_quantification/alignment_quantification.wdl
@@ -187,7 +187,8 @@ task index_aligned_bam {
 
 		samtools index \
 			-@ ~{threads} \
-			~{aligned_bam}
+			~{aligned_bam} \
+			-o "./~{sample_id}.Aligned.sortedByCoord.out.bam.bai"
 
 		upload_outputs \
 			-b ~{billing_project} \

--- a/workflows/upstream/alignment_quantification/alignment_quantification.wdl
+++ b/workflows/upstream/alignment_quantification/alignment_quantification.wdl
@@ -99,7 +99,7 @@ task alignment {
 
 		tar -xzvf ~{star_genome_dir_tar_gz}
 
-		STAR \
+		/usr/bin/time -v STAR \
 			--runThreadN ~{threads - 1} \
 			--genomeDir star_genome_dir \
 			--readFilesIn ~{sep=',' trimmed_fastq_R1s} ~{sep=',' trimmed_fastq_R2s} \
@@ -112,10 +112,14 @@ task alignment {
 			--alignMatesGapMax 1000000 \
 			--twopassMode Basic \
 			--quantMode TranscriptomeSAM \
-			--limitBAMsortRAM 35000000000
+			--limitBAMsortRAM 50000000000
+
+		sleep 30
 
 		echo "Syncing filesystem..."
 		sync
+
+		sleep 30
 
 		echo "Verifying BAM file integrity..."
 		samtools quickcheck -v ~{sample_id}.Aligned.sortedByCoord.out.bam

--- a/workflows/upstream/alignment_quantification/alignment_quantification.wdl
+++ b/workflows/upstream/alignment_quantification/alignment_quantification.wdl
@@ -99,31 +99,10 @@ task alignment {
 			--alignMatesGapMax 1000000 \
 			--twopassMode Basic \
 			--quantMode TranscriptomeSAM \
-			--limitBAMsortRAM 70000000000
+			--limitBAMsortRAM 80000000000 # should not exceed ~{mem_gb}
 
-		# Keep checking until BAM is valid because STAR might not be done writing the files
-		validate_bam() {
-			local bam_file="$1"
-			local max_attempts=60  # 10 minutes
-			local attempt=0
-
-			while [ $attempt -lt $max_attempts ]; do
-				if samtools quickcheck "$bam_file" 2>/dev/null; then
-					echo "BAM validated after $((attempt * 10)) seconds"
-					return 0
-				fi
-
-				echo "BAM not ready, syncing and waiting... (attempt $attempt)"
-				sync
-				sleep 10
-				attempt=$((attempt + 1))
-			done
-
-			echo "BAM failed validation after $((max_attempts * 10)) seconds"
-			samtools quickcheck -v "$bam_file"
-		}
-
-		validate_bam "~{sample_id}.Aligned.sortedByCoord.out.bam"
+		echo "Validating aligned and sorted BAM"
+		samtools quickcheck "~{sample_id}.Aligned.sortedByCoord.out.bam"
 
 		echo "Indexing aligned and sorted BAM"
 		samtools index \

--- a/workflows/upstream/alignment_quantification/alignment_quantification.wdl
+++ b/workflows/upstream/alignment_quantification/alignment_quantification.wdl
@@ -86,6 +86,7 @@ task alignment {
 
 		tar -xzvf ~{star_genome_dir_tar_gz}
 
+		/usr/bin/time \
 		STAR \
 			--runThreadN ~{threads - 1} \
 			--genomeDir star_genome_dir \


### PR DESCRIPTION
## Description
Ran Team Jakobsson's bulk data through the pipeline and experienced silent errors in STAR alignment due to its larger data compared to other Teams. When there's a large BAM to sort, the WDL task will finish before the file actually closes, resulting in an empty Aligned.sortedByCoord.out.bam without any error messages. In order to deal with network filesystem and file handle closure, I had to increase the disk size and switch to SSD and added the `--limitBAMsortRAM` flag. 

## Dependencies (Issues/PRs)
[BIOS-1513](https://app.clickup.com/t/9014209604/BIOS-1513)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation

## Task Checklist
- [x] documentation updated
- [x] `miniwdl check` passed
- [x] `womtool validate` passed


## Testing
### Workflow Engine Tested On
- [ ] HealthOmics, Amazon Web Services
- [x] Google Cloud Platform, Cromwell
- [ ] Google Cloud Platform
- [ ] Microsoft Azure, Cromwell
- [ ] GA4GH Workflow Execution Service, On Premises and Multi Cloud
- [ ] Other

### Successful Workflow IDs
* `3c93da69-135d-4ff7-afd1-2f43125466d8`
* `66953f60-37a0-49c5-a29e-fa9799bd1bdb`
